### PR TITLE
Protocol Fees (Set to 20%)

### DIFF
--- a/contracts/Rln.sol
+++ b/contracts/Rln.sol
@@ -6,6 +6,8 @@ contract RLN {
 	uint256 public immutable MEMBERSHIP_DEPOSIT;
 	uint256 public immutable DEPTH;
 	uint256 public immutable SET_SIZE;
+	uint256 public immutable WAD = 10 ** 18;
+	uint256 public immutable PROTOCOL_FEES_PERCENTAGE = 2 * 10 ** 17;// 20 Percent fees
 
 	uint256 public pubkeyIndex = 0;
 	mapping(uint256 => uint256) public members;
@@ -86,7 +88,8 @@ contract RLN {
 		members[_pubkeyIndex] = 0;
 
 		// refund deposit
-		(bool sent, _) = receiver.call{value: MEMBERSHIP_DEPOSIT}("");
+		uint256 withdrawableDeposit = MEMBERSHIP_DEPOSIT * (WAD - PROTOCOL_FEES_PERCENTAGE) / WAD
+		(bool sent, _) = receiver.call{value: withdrawableDeposit}("");
         require(sent, "transfer failed");
 
 		emit MemberWithdrawn(pubkey, _pubkeyIndex);


### PR DESCRIPTION
This is the implementation for incorporating the fees that will be reserved for protocol usage. The commission collected can be used for incentivising different stakeholders. The current fees is set to 20 % and hard coded to take into account the format of decimals in solidity language. This code only aims to hold back the commission and does not show how to utilise or withdraw it from the contract at the moment. The issue for the same can be found at https://github.com/vacp2p/rfc/issues/485