### PR TITLE
Adds link to the rlnapp repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The [RLN](contracts/Rln.sol) and [PoseidonHasher](contracts/PoseidonHasher.sol) smart contracts are initially borrowed from the following repository https://github.com/kilic/rlnapp and some minor modifications are made on top of them.
+The [RLN](contracts/Rln.sol) and [PoseidonHasher](contracts/PoseidonHasher.sol) smart contracts are initially borrowed from the following repository https://github.com/kilic/rlnapp and some modifications are made on top of them.
 They may undertake further changes in the future as needed.
 
 # Hardhat Project for Rln-membership-contract

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+The [RLN](contracts/Rln.sol) and [PoseidonHasher](contracts/PoseidonHasher.sol) smart contracts are initially borrowed from the following repository https://github.com/kilic/rlnapp and some minor modifications are made on top of them.
+They may undertake further changes in the future as needed.
+
 # Hardhat Project for Rln-membership-contract
 
 ## Compilation


### PR DESCRIPTION
This PR is to attribute where the RLN and PoseidonHasher smart contract codes are initially from. Note that it does not capture the exact modifications that happened on top of the original versions. 
