### PR TITLE
fix: make tests compile with forge-std@1.6.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	branch = v1.5.2
+	branch = v1.6.0

--- a/test/Rln.t.sol
+++ b/test/Rln.t.sol
@@ -77,7 +77,7 @@ contract RlnTest is Test {
         // avoid precompiles, etc
         // TODO: wrap both of these in a single function
         assumePayable(to);
-        assumeNoPrecompiles(to);
+        assumeNotPrecompile(to);
         vm.assume(to != address(0));
 
         rln.register{value: MEMBERSHIP_DEPOSIT}(idCommitment);
@@ -118,7 +118,7 @@ contract RlnTest is Test {
     function test__InvalidSlash__NoStake(uint256 idCommitment, address payable to) public {
         // avoid precompiles, etc
         assumePayable(to);
-        assumeNoPrecompiles(to);
+        assumeNotPrecompile(to);
         vm.assume(to != address(0));
 
         rln.register{value: MEMBERSHIP_DEPOSIT}(idCommitment);
@@ -171,7 +171,7 @@ contract RlnTest is Test {
 
     function test__ValidWithdraw(address payable to) public {
         assumePayable(to);
-        assumeNoPrecompiles(to);
+        assumeNotPrecompile(to);
 
         uint256 idCommitment = 19014214495641488759237505126948346942972912379615652741039992445865937985820;
 


### PR DESCRIPTION
There was a breaking change introduced in `forge-std` at https://github.com/foundry-rs/forge-std/pull/407 which breaks compilation of `Rln.t.sol` with `forge-std@v1.6.0`.

This commit updates the dependency to v1.6.0 and adjusts the test source such that it successfully compiles.

Another way to go about this would've been to just stick with `v1.5.6.` and ensuring installation of that version.
However, I've decided to update the dependency to the latest stable version instead.