### PR TITLE
chore: use deployed block number

### DIFF
--- a/contracts/RlnBase.sol
+++ b/contracts/RlnBase.sol
@@ -70,6 +70,9 @@ abstract contract RlnBase {
     /// @notice The groth16 verifier contract
     IVerifier public immutable verifier;
 
+    /// @notice the deployed block number
+    uint256 public immutable deployedBlockNumber;
+
     /// Emitted when a new member is added to the set
     /// @param idCommitment The idCommitment of the member
     /// @param index The index of the member in the set
@@ -91,6 +94,7 @@ abstract contract RlnBase {
         SET_SIZE = 1 << depth;
         poseidonHasher = PoseidonHasher(_poseidonHasher);
         verifier = IVerifier(_verifier);
+        deployedBlockNumber = block.number;
     }
 
     /// Allows a user to register as a member

--- a/contracts/RlnBase.sol
+++ b/contracts/RlnBase.sol
@@ -71,7 +71,7 @@ abstract contract RlnBase {
     IVerifier public immutable verifier;
 
     /// @notice the deployed block number
-    uint256 public immutable deployedBlockNumber;
+    uint32 public immutable deployedBlockNumber;
 
     /// Emitted when a new member is added to the set
     /// @param idCommitment The idCommitment of the member
@@ -94,7 +94,7 @@ abstract contract RlnBase {
         SET_SIZE = 1 << depth;
         poseidonHasher = PoseidonHasher(_poseidonHasher);
         verifier = IVerifier(_verifier);
-        deployedBlockNumber = block.number;
+        deployedBlockNumber = uint32(block.number);
     }
 
     /// Allows a user to register as a member

--- a/docs/index.md
+++ b/docs/index.md
@@ -1040,7 +1040,7 @@ The groth16 verifier contract
 ### deployedBlockNumber
 
 ```solidity
-uint256 deployedBlockNumber
+uint32 deployedBlockNumber
 ```
 
 the deployed block number
@@ -1074,12 +1074,6 @@ Emitted when a member is removed from the set
 | ------------ | ------- | ---------------------------------- |
 | idCommitment | uint256 | The idCommitment of the member     |
 | index        | uint256 | The index of the member in the set |
-
-### onlyValidIdCommitment
-
-```solidity
-modifier onlyValidIdCommitment(uint256 idCommitment)
-```
 
 ### onlyValidIdCommitment
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ Hashes the input using the Poseidon hash function, n = 2, second input is the co
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description       |
+| ----- | ------- | ----------------- |
 | input | uint256 | The input to hash |
 
 ## PoseidonHasher
@@ -834,11 +834,11 @@ Hashes the input using the Poseidon hash function, n = 2, second input is the co
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description       |
+| ----- | ------- | ----------------- |
 | input | uint256 | The input to hash |
 
-### _hash
+### \_hash
 
 ```solidity
 function _hash(uint256 input) internal pure returns (uint256 result)
@@ -852,7 +852,7 @@ function _hash(uint256 input) internal pure returns (uint256 result)
 constructor(uint256 membershipDeposit, uint256 depth, address _poseidonHasher, address _verifier) public
 ```
 
-### _validateRegistration
+### \_validateRegistration
 
 ```solidity
 function _validateRegistration(uint256 idCommitment) internal pure
@@ -860,7 +860,7 @@ function _validateRegistration(uint256 idCommitment) internal pure
 
 _Inheriting contracts MUST override this function_
 
-### _validateSlash
+### \_validateSlash
 
 ```solidity
 function _validateSlash(uint256 idCommitment, address payable receiver, uint256[8] proof) internal pure
@@ -884,8 +884,8 @@ Invalid deposit amount
 
 ### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description                 |
+| -------- | ------- | --------------------------- |
 | required | uint256 | The required deposit amount |
 | provided | uint256 | The provided deposit amount |
 
@@ -1037,6 +1037,14 @@ contract IVerifier verifier
 
 The groth16 verifier contract
 
+### deployedBlockNumber
+
+```solidity
+uint256 deployedBlockNumber
+```
+
+the deployed block number
+
 ### MemberRegistered
 
 ```solidity
@@ -1047,10 +1055,10 @@ Emitted when a new member is added to the set
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| idCommitment | uint256 | The idCommitment of the member |
-| index | uint256 | The index of the member in the set |
+| Name         | Type    | Description                        |
+| ------------ | ------- | ---------------------------------- |
+| idCommitment | uint256 | The idCommitment of the member     |
+| index        | uint256 | The index of the member in the set |
 
 ### MemberWithdrawn
 
@@ -1062,10 +1070,16 @@ Emitted when a member is removed from the set
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| idCommitment | uint256 | The idCommitment of the member |
-| index | uint256 | The index of the member in the set |
+| Name         | Type    | Description                        |
+| ------------ | ------- | ---------------------------------- |
+| idCommitment | uint256 | The idCommitment of the member     |
+| index        | uint256 | The index of the member in the set |
+
+### onlyValidIdCommitment
+
+```solidity
+modifier onlyValidIdCommitment(uint256 idCommitment)
+```
 
 ### onlyValidIdCommitment
 
@@ -1089,11 +1103,11 @@ Allows a user to register as a member
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name         | Type    | Description                    |
+| ------------ | ------- | ------------------------------ |
 | idCommitment | uint256 | The idCommitment of the member |
 
-### _register
+### \_register
 
 ```solidity
 function _register(uint256 idCommitment, uint256 stake) internal virtual
@@ -1103,12 +1117,12 @@ Registers a member
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| idCommitment | uint256 | The idCommitment of the member |
-| stake | uint256 | The amount of eth staked by the member |
+| Name         | Type    | Description                            |
+| ------------ | ------- | -------------------------------------- |
+| idCommitment | uint256 | The idCommitment of the member         |
+| stake        | uint256 | The amount of eth staked by the member |
 
-### _validateRegistration
+### \_validateRegistration
 
 ```solidity
 function _validateRegistration(uint256 idCommitment) internal view virtual
@@ -1126,13 +1140,13 @@ _Allows a user to slash a member_
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| idCommitment | uint256 | The idCommitment of the member |
-| receiver | address payable |  |
-| proof | uint256[8] |  |
+| Name         | Type            | Description                    |
+| ------------ | --------------- | ------------------------------ |
+| idCommitment | uint256         | The idCommitment of the member |
+| receiver     | address payable |                                |
+| proof        | uint256[8]      |                                |
 
-### _slash
+### \_slash
 
 ```solidity
 function _slash(uint256 idCommitment, address payable receiver, uint256[8] proof) internal virtual
@@ -1143,13 +1157,13 @@ stake to the receiver's available withdrawal balance_
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| idCommitment | uint256 | The idCommitment of the member |
-| receiver | address payable | The address to receive the funds |
-| proof | uint256[8] |  |
+| Name         | Type            | Description                      |
+| ------------ | --------------- | -------------------------------- |
+| idCommitment | uint256         | The idCommitment of the member   |
+| receiver     | address payable | The address to receive the funds |
+| proof        | uint256[8]      |                                  |
 
-### _validateSlash
+### \_validateSlash
 
 ```solidity
 function _validateSlash(uint256 idCommitment, address payable receiver, uint256[8] proof) internal view virtual
@@ -1174,8 +1188,8 @@ NOTE: The variant of Poseidon we use accepts only 1 input, assume n=2, and the s
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description       |
+| ----- | ------- | ----------------- |
 | input | uint256 | The value to hash |
 
 ### isValidCommitment
@@ -1184,7 +1198,7 @@ NOTE: The variant of Poseidon we use accepts only 1 input, assume n=2, and the s
 function isValidCommitment(uint256 idCommitment) public view returns (bool)
 ```
 
-### _verifyProof
+### \_verifyProof
 
 ```solidity
 function _verifyProof(uint256 idCommitment, address receiver, uint256[8] proof) internal view virtual returns (bool)
@@ -1220,9 +1234,9 @@ function P1() internal pure returns (struct Pairing.G1Point)
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | struct Pairing.G1Point | the generator of G1 |
+| Name | Type                   | Description         |
+| ---- | ---------------------- | ------------------- |
+| [0]  | struct Pairing.G1Point | the generator of G1 |
 
 ### P2
 
@@ -1232,9 +1246,9 @@ function P2() internal pure returns (struct Pairing.G2Point)
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | struct Pairing.G2Point | the generator of G2 |
+| Name | Type                   | Description         |
+| ---- | ---------------------- | ------------------- |
+| [0]  | struct Pairing.G2Point | the generator of G2 |
 
 ### negate
 
@@ -1244,9 +1258,9 @@ function negate(struct Pairing.G1Point p) internal pure returns (struct Pairing.
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| r | struct Pairing.G1Point | the negation of p, i.e. p.addition(p.negate()) should be zero. |
+| Name | Type                   | Description                                                    |
+| ---- | ---------------------- | -------------------------------------------------------------- |
+| r    | struct Pairing.G1Point | the negation of p, i.e. p.addition(p.negate()) should be zero. |
 
 ### addition
 
@@ -1256,9 +1270,9 @@ function addition(struct Pairing.G1Point p1, struct Pairing.G1Point p2) internal
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| r | struct Pairing.G1Point | the sum of two points of G1 |
+| Name | Type                   | Description                 |
+| ---- | ---------------------- | --------------------------- |
+| r    | struct Pairing.G1Point | the sum of two points of G1 |
 
 ### scalar_mul
 
@@ -1268,9 +1282,9 @@ function scalar_mul(struct Pairing.G1Point p, uint256 s) internal view returns (
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| r | struct Pairing.G1Point | the product of a point on G1 and a scalar, i.e. p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p. |
+| Name | Type                   | Description                                                                                                                 |
+| ---- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| r    | struct Pairing.G1Point | the product of a point on G1 and a scalar, i.e. p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p. |
 
 ### pairing
 
@@ -1280,9 +1294,9 @@ function pairing(struct Pairing.G1Point[] p1, struct Pairing.G2Point[] p2) inter
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | the result of computing the pairing check e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1 For example pairing([P1(), P1().negate()], [P2(), P2()]) should return true. |
+| Name | Type | Description                                                                                                                                                          |
+| ---- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [0]  | bool | the result of computing the pairing check e(p1[0], p2[0]) _ .... _ e(p1[n], p2[n]) == 1 For example pairing([P1(), P1().negate()], [P2(), P2()]) should return true. |
 
 ### pairingProd2
 
@@ -1352,7 +1366,6 @@ function verifyProof(uint256[2] a, uint256[2][2] b, uint256[2] c, uint256[2] inp
 
 #### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| r | bool | bool true if proof is valid |
-
+| Name | Type | Description                 |
+| ---- | ---- | --------------------------- |
+| r    | bool | bool true if proof is valid |

--- a/test/Rln.t.sol
+++ b/test/Rln.t.sol
@@ -34,6 +34,7 @@ contract RlnTest is Test {
         assertEq(rln.MEMBERSHIP_DEPOSIT(), MEMBERSHIP_DEPOSIT);
         assertEq(rln.DEPTH(), DEPTH);
         assertEq(rln.SET_SIZE(), SET_SIZE);
+        assertEq(rln.deployedBlockNumber(), 1);
     }
 
     function test__ValidRegistration(uint256 idCommitment) public {


### PR DESCRIPTION
- chore: add deployed block number to the contract


The `deployedBlockNumber` variable is used so that clients can directly start listening to events from this block 
